### PR TITLE
add data abstraction layer to support future api

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import BasemapPicker from './BasemapPicker'
 import ViewNav from './ViewNav'
 import InfoPanel from './InfoPanel'
 import DefineArea from './DefineArea'
+import { data } from './data.js'
 
 const IS_DEMO = import.meta.env.VITE_DATA_SOURCE !== 'api'
 
@@ -214,7 +215,7 @@ function App() {
     m.on('load', async () => {
       initSamDecoder().then(() => console.log('SAM decoder ready'))
 
-      const resp = await fetch(`${import.meta.env.BASE_URL}data/metadata.geojson`)
+      const resp = await fetch(data.chipsUrl())
       const raw = await resp.json()
 
       // Index original features by chip ID so we can look up exact coordinates
@@ -365,7 +366,7 @@ function App() {
 
         m.addSource('chip-overlay', {
           type: 'image',
-          url: `${import.meta.env.BASE_URL}data/chips/${chipId}.png`,
+          url: data.chipImageUrl(chipId),
           coordinates: imageCoords,
         })
         m.addLayer({
@@ -376,7 +377,7 @@ function App() {
 
         m.addSource('cam-overlay', {
           type: 'image',
-          url: `${import.meta.env.BASE_URL}data/cams/${chipId}.png`,
+          url: data.chipCamUrl(chipId),
           coordinates: imageCoords,
         })
         m.addLayer({
@@ -420,8 +421,8 @@ function App() {
 
         // Load embedding and raw CAM in parallel
         const [embedding, camRaw] = await Promise.all([
-          loadNpy(`${import.meta.env.BASE_URL}data/sam_embeddings/${chipId}.npy`),
-          loadNpy(`${import.meta.env.BASE_URL}data/cams_raw/${chipId}.npy`).catch(() => null),
+          loadNpy(data.embeddingUrl(chipId)),
+          loadNpy(data.chipCamRawUrl(chipId)).catch(() => null),
         ])
         activeEmbedding = embedding
         activeCamMask = camRaw ? camToMaskInput(camRaw) : null

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,12 @@
+const BASE = import.meta.env.BASE_URL
+const API = import.meta.env.VITE_API_BASE || ''
+const STATIC = import.meta.env.VITE_DATA_SOURCE !== 'api'
+
+export const data = {
+  chipsUrl:      ()   => STATIC ? `${BASE}data/metadata.geojson`        : `${API}/api/chips`,
+  chipImageUrl:  (id) => STATIC ? `${BASE}data/chips/${id}.png`          : `${API}/api/chips/${id}/image`,
+  chipCamUrl:    (id) => STATIC ? `${BASE}data/cams/${id}.png`           : `${API}/api/chips/${id}/cam`,
+  chipCamRawUrl: (id) => STATIC ? `${BASE}data/cams_raw/${id}.npy`       : `${API}/api/chips/${id}/cam-raw`,
+  embeddingUrl:  (id) => STATIC ? `${BASE}data/sam_embeddings/${id}.npy` : `${API}/api/chips/${id}/embedding`,
+  samDecoderUrl: ()   => STATIC ? `${BASE}data/sam_decoder.onnx`         : `${API}/api/models/sam-decoder`,
+}

--- a/src/sam.js
+++ b/src/sam.js
@@ -1,4 +1,5 @@
 import * as ort from 'onnxruntime-web'
+import { data } from './data.js'
 
 let session = null
 
@@ -9,7 +10,7 @@ let sessionReady = null
 
 export async function initSamDecoder() {
   if (sessionReady) return sessionReady
-  sessionReady = ort.InferenceSession.create(`${import.meta.env.BASE_URL}data/sam_decoder.onnx`)
+  sessionReady = ort.InferenceSession.create(data.samDecoderUrl())
     .then((s) => {
       session = s
       console.log('SAM decoder inputs:', session.inputNames)


### PR DESCRIPTION
Adds data.js, which serves assets depending on whether the app is in demo mode or not. Demo mode uses pre-computed local assets, while API mode sends calls to the API.