### PR TITLE
use spatial DuckDB, move all chip logic to server from frontend

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import duckdb
@@ -13,12 +14,14 @@ def init_db():
     db_path = Path(cfg["db_path"])
     db_path.parent.mkdir(parents=True, exist_ok=True)
     _conn = duckdb.connect(str(db_path))
+    _conn.execute("INSTALL spatial")
+    _conn.execute("LOAD spatial")
     _conn.execute("""
         CREATE TABLE IF NOT EXISTS chips (
             id TEXT PRIMARY KEY,
             split TEXT NOT NULL,
             status TEXT NOT NULL DEFAULT 'unlabeled',
-            geometry_wkt TEXT NOT NULL
+            geometry GEOMETRY NOT NULL
         )
     """)
 
@@ -29,21 +32,25 @@ def get_db():
     return _conn
 
 
-def insert_chips(chips):
+def insert_chips(chips, crs):
     """Batch insert chips, skipping duplicates."""
     conn = get_db()
     for chip in chips:
         conn.execute(
-            "INSERT OR IGNORE INTO chips (id, split, status, geometry_wkt) VALUES (?, ?, 'unlabeled', ?)",
+            "INSERT OR IGNORE INTO chips (id, split, status, geometry) VALUES (?, ?, 'unlabeled', ST_GeomFromText(?))",
             [chip["id"], chip["split"], chip["geometry_wkt"]],
         )
 
 
 def get_all_chips():
     conn = get_db()
-    rows = conn.execute("SELECT id, split, status, geometry_wkt FROM chips").fetchall()
+    cfg = get_config()
+    crs = cfg["crs"]
+    rows = conn.execute(
+        f"SELECT id, split, status, ST_AsGeoJSON(ST_FlipCoordinates(ST_Transform(geometry, '{crs}', 'EPSG:4326'))) AS geojson FROM chips"
+    ).fetchall()
     return [
-        {"id": r[0], "split": r[1], "status": r[2], "geometry_wkt": r[3]}
+        {"id": r[0], "split": r[1], "status": r[2], "geojson": json.loads(r[3])}
         for r in rows
     ]
 

--- a/server/grid.py
+++ b/server/grid.py
@@ -6,13 +6,11 @@ from pyproj import Transformer
 def compute_grid(sw_lonlat, ne_lonlat, split, chip_size_m, crs, max_chips=None):
     """Compute a UTM-snapped chip grid for a bounding box.
 
-    Returns a list of dicts with keys: id, split, geometry_wkt, geojson_coords.
-    geometry_wkt is the polygon in the projected CRS.
-    geojson_coords is the coordinate ring in [lon, lat] for GeoJSON output,
+    Returns a list of dicts with keys: id, split, geometry_wkt.
+    geometry_wkt is the polygon in the projected CRS,
     vertex order: [NE, SE, SW, NW, NE] to match existing metadata.geojson.
     """
     to_proj = Transformer.from_crs("EPSG:4326", crs, always_xy=True)
-    to_wgs = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
 
     sw_e, sw_n = to_proj.transform(sw_lonlat[0], sw_lonlat[1])
     ne_e, ne_n = to_proj.transform(ne_lonlat[0], ne_lonlat[1])
@@ -46,26 +44,10 @@ def compute_grid(sw_lonlat, ne_lonlat, split, chip_size_m, crs, max_chips=None):
                 f"POLYGON(({e2} {n2}, {e2} {n}, {e} {n}, {e} {n2}, {e2} {n2}))"
             )
 
-            # Transform corners to lon/lat
-            ne_lon, ne_lat = to_wgs.transform(e2, n2)
-            se_lon, se_lat = to_wgs.transform(e2, n)
-            sw_lon, sw_lat = to_wgs.transform(e, n)
-            nw_lon, nw_lat = to_wgs.transform(e, n2)
-
-            # GeoJSON ring: [NE, SE, SW, NW, NE]
-            geojson_coords = [
-                [ne_lon, ne_lat],
-                [se_lon, se_lat],
-                [sw_lon, sw_lat],
-                [nw_lon, nw_lat],
-                [ne_lon, ne_lat],
-            ]
-
             chips.append({
                 "id": chip_id,
                 "split": split,
                 "geometry_wkt": wkt,
-                "geojson_coords": geojson_coords,
             })
 
             n += chip_size_m

--- a/server/routers/chips.py
+++ b/server/routers/chips.py
@@ -1,35 +1,9 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
-from pyproj import Transformer
 
-from server.config import get_config
 from server.db import get_all_chips, delete_chips as db_delete_chips
 
 router = APIRouter(prefix="/api")
-
-_transformer = None
-
-
-def _get_transformer():
-    global _transformer
-    if _transformer is None:
-        cfg = get_config()
-        _transformer = Transformer.from_crs(cfg["crs"], "EPSG:4326", always_xy=True)
-    return _transformer
-
-
-def _wkt_to_lonlat_ring(wkt):
-    """Parse a simple POLYGON WKT in projected CRS and return a lon/lat coordinate ring."""
-    # WKT format: POLYGON((x1 y1, x2 y2, ...))
-    inner = wkt.split("((")[1].rstrip("))")
-    pairs = inner.split(", ")
-    t = _get_transformer()
-    ring = []
-    for pair in pairs:
-        x, y = pair.split()
-        lon, lat = t.transform(float(x), float(y))
-        ring.append([lon, lat])
-    return ring
 
 
 class DeleteChipsRequest(BaseModel):
@@ -41,7 +15,6 @@ def list_chips():
     chips = get_all_chips()
     features = []
     for chip in chips:
-        ring = _wkt_to_lonlat_ring(chip["geometry_wkt"])
         features.append({
             "type": "Feature",
             "properties": {
@@ -50,10 +23,7 @@ def list_chips():
                 "split": chip["split"],
                 "label": None,
             },
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [ring],
-            },
+            "geometry": chip["geojson"],
         })
 
     return {

--- a/server/routers/study_areas.py
+++ b/server/routers/study_areas.py
@@ -35,25 +35,6 @@ def create_study_area(req: CreateStudyAreaRequest):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    insert_chips(chips)
+    insert_chips(chips, crs=cfg["crs"])
 
-    features = []
-    for chip in chips:
-        features.append({
-            "type": "Feature",
-            "properties": {
-                "id": chip["id"],
-                "status": "unlabeled",
-                "split": chip["split"],
-                "label": None,
-            },
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [chip["geojson_coords"]],
-            },
-        })
-
-    return {
-        "type": "FeatureCollection",
-        "features": features,
-    }
+    return {"ok": True, "count": len(chips)}

--- a/src/hooks/useChipGrid.js
+++ b/src/hooks/useChipGrid.js
@@ -35,10 +35,11 @@ export function useChipGrid(map) {
       source: 'chips',
       paint: {
         'fill-color': [
-          'case',
-          ['==', ['get', 'label'], 'present'],
-          '#22c55e',
-          '#ef4444',
+          'match', ['get', 'split'],
+          'train', '#3b82f6',
+          'test', '#ef4444',
+          'validate', '#f59e0b',
+          '#888888',
         ],
         'fill-opacity': 0.15,
       },
@@ -50,10 +51,11 @@ export function useChipGrid(map) {
       source: 'chips',
       paint: {
         'line-color': [
-          'case',
-          ['==', ['get', 'label'], 'present'],
-          '#22c55e',
-          '#ef4444',
+          'match', ['get', 'split'],
+          'train', '#3b82f6',
+          'test', '#ef4444',
+          'validate', '#f59e0b',
+          '#888888',
         ],
         'line-width': 1.5,
       },

--- a/src/views/useDefineAreaView.js
+++ b/src/views/useDefineAreaView.js
@@ -1,49 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import proj4 from 'proj4'
 import { data } from '../data.js'
-
-const IS_DEMO = import.meta.env.VITE_DATA_SOURCE !== 'api'
-const CHIP_SIZE_M = 76.8
-
-proj4.defs('EPSG:32619', '+proj=utm +zone=19 +datum=WGS84 +units=m +no_defs')
-
-function computeGrid(sw, ne, split) {
-  const swUtm = proj4('EPSG:4326', 'EPSG:32619', sw)
-  const neUtm = proj4('EPSG:4326', 'EPSG:32619', ne)
-
-  const minE = Math.floor(swUtm[0] / CHIP_SIZE_M) * CHIP_SIZE_M
-  const minN = Math.floor(swUtm[1] / CHIP_SIZE_M) * CHIP_SIZE_M
-  const maxE = Math.ceil(neUtm[0] / CHIP_SIZE_M) * CHIP_SIZE_M
-  const maxN = Math.ceil(neUtm[1] / CHIP_SIZE_M) * CHIP_SIZE_M
-
-  const features = []
-  for (let e = minE; e < maxE; e += CHIP_SIZE_M) {
-    for (let n = minN; n < maxN; n += CHIP_SIZE_M) {
-      const sw_ll = proj4('EPSG:32619', 'EPSG:4326', [e, n])
-      const se_ll = proj4('EPSG:32619', 'EPSG:4326', [e + CHIP_SIZE_M, n])
-      const ne_ll = proj4('EPSG:32619', 'EPSG:4326', [e + CHIP_SIZE_M, n + CHIP_SIZE_M])
-      const nw_ll = proj4('EPSG:32619', 'EPSG:4326', [e, n + CHIP_SIZE_M])
-
-      features.push({
-        type: 'Feature',
-        geometry: {
-          type: 'Polygon',
-          coordinates: [[nw_ll, ne_ll, se_ll, sw_ll, nw_ll]],
-        },
-        properties: {
-          split,
-          id: `${e.toFixed(2)}e_${n.toFixed(2)}n`,
-        },
-      })
-    }
-  }
-  return features
-}
 
 export function useDefineAreaView({ active, map, chipGrid }) {
   const [drawMode, setDrawMode] = useState(false)
   const [activeSplit, setActiveSplit] = useState('train')
-  const [studyAreas, setStudyAreas] = useState([])
 
   const drawModeRef = useRef(false)
   const activeSplitRef = useRef('train')
@@ -67,54 +27,10 @@ export function useDefineAreaView({ active, map, chipGrid }) {
     }
   }, [map, drawMode])
 
-  // Sync study areas to map source
-  useEffect(() => {
-    if (!map || !map.getSource('study-areas')) return
-    map.getSource('study-areas').setData({
-      type: 'FeatureCollection',
-      features: studyAreas,
-    })
-  }, [map, studyAreas])
-
-  // Add sources/layers and event handlers
+  // Add draw-rect source/layer
   useEffect(() => {
     if (!map || initializedRef.current) return
     initializedRef.current = true
-
-    map.addSource('study-areas', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: [] },
-    })
-    map.addLayer({
-      id: 'study-areas-fill',
-      type: 'fill',
-      source: 'study-areas',
-      paint: {
-        'fill-color': [
-          'match', ['get', 'split'],
-          'train', '#3b82f6',
-          'test', '#ef4444',
-          'validate', '#f59e0b',
-          '#888888',
-        ],
-        'fill-opacity': 0.15,
-      },
-    })
-    map.addLayer({
-      id: 'study-areas-outline',
-      type: 'line',
-      source: 'study-areas',
-      paint: {
-        'line-color': [
-          'match', ['get', 'split'],
-          'train', '#3b82f6',
-          'test', '#ef4444',
-          'validate', '#f59e0b',
-          '#888888',
-        ],
-        'line-width': 2,
-      },
-    })
 
     map.addSource('draw-rect', {
       type: 'geojson',
@@ -199,17 +115,9 @@ export function useDefineAreaView({ active, map, chipGrid }) {
 
       const split = activeSplitRef.current
 
-      if (IS_DEMO) {
-        const gridFeatures = computeGrid(sw, ne, split)
-        setStudyAreas((prev) => [...prev, ...gridFeatures])
-      } else {
-        data.createStudyArea({ sw, ne }, split).then((geojson) => {
-          if (geojson.features) {
-            setStudyAreas((prev) => [...prev, ...geojson.features])
-            chipGrid.refreshChips()
-          }
-        })
-      }
+      data.createStudyArea({ sw, ne }, split).then(() => {
+        chipGrid.refreshChips()
+      })
 
       // Auto-exit draw mode
       setDrawMode(false)

--- a/src/views/useLabelingView.js
+++ b/src/views/useLabelingView.js
@@ -104,10 +104,11 @@ export function useLabelingView({ active, map, featureById }) {
       setSelectedChipId(null)
       if (map.getLayer('chips-outline')) {
         map.setPaintProperty('chips-outline', 'line-color', [
-          'case',
-          ['==', ['get', 'label'], 'present'],
-          '#22c55e',
-          '#ef4444',
+          'match', ['get', 'split'],
+          'train', '#3b82f6',
+          'test', '#ef4444',
+          'validate', '#f59e0b',
+          '#888888',
         ])
         map.setPaintProperty('chips-outline', 'line-width', 1.5)
       }
@@ -221,11 +222,11 @@ export function useLabelingView({ active, map, featureById }) {
         'case',
         ['==', ['get', 'id'], chipId],
         '#facc15',
-        [
-          'case',
-          ['==', ['get', 'label'], 'present'],
-          '#22c55e',
-          '#ef4444',
+        ['match', ['get', 'split'],
+          'train', '#3b82f6',
+          'test', '#ef4444',
+          'validate', '#f59e0b',
+          '#888888',
         ],
       ])
       map.setPaintProperty('chips-outline', 'line-width', [


### PR DESCRIPTION
The Define Area View no longer computes chip grids on the front end, instead delegating to the server, which writes to DuckDB. The frontend now only queries chips from DuckDB, the authoritative chip tracker. Chips are no longer doubled up in memory on the frontend. This will support further geospatial operations on chips as well as scalability.