### PR TITLE
Refactor/issue 27 frontend optimization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,14 +59,14 @@ function AppInner() {
             brushSize={labeling.paintbrush.brushSize}
             paintAt={labeling.paintbrush.paintAt}
             compositeMask={labeling.paintbrush.compositeMask}
-            samMask={labeling.currentSamMask}
+            samMaskRef={labeling.currentSamMaskRef}
             onMaskUpdate={labeling.handleMaskUpdate}
           />
           <StatusBar
             selectedChipId={labeling.selectedChipId}
             clickPoints={labeling.clickPoints}
             maskIndex={labeling.maskIndex}
-            maskResults={labeling.maskResults}
+            maskInfo={labeling.maskInfo}
             paintMode={labeling.paintbrush.paintMode}
             brushSize={labeling.paintbrush.brushSize}
             deleteMode={labeling.deleteMode}

--- a/src/InfoPanel.jsx
+++ b/src/InfoPanel.jsx
@@ -32,6 +32,7 @@ function InfoPanel() {
           <li>Use <kbd>[</kbd> and <kbd>]</kbd> to select the best mask.</li>
           <li>Prompt with more points iteratively.</li>
           <li><kbd>b</kbd> triggers painting mode to manually correct SAM predictions as a final step.</li>
+          <li><kbd>Enter</kbd> previews a vectorized SAM mask that is sent to the label database in the full version.</li>
         </ul>
       </div>
     </div>

--- a/src/PaintbrushOverlay.jsx
+++ b/src/PaintbrushOverlay.jsx
@@ -17,6 +17,7 @@ export default function PaintbrushOverlay({
   const paintingRef = useRef(false)
   const rafRef = useRef(null)
   const dirtyRef = useRef(false)
+  const inFlightRef = useRef(false)
 
   // Convert screen coords to SAM_MASK_SIZE pixel coords using all four
   // projected chip corners. Uses inverse bilinear interpolation so that
@@ -84,25 +85,31 @@ export default function PaintbrushOverlay({
   }, [map, chipCorners])
 
   // Update the MapLibre image source with current composited mask
-  const updateOverlay = useCallback(() => {
+  const updateOverlay = useCallback(async () => {
     if (!map || !chipCorners) return
-    const composited = compositeMask(samMask)
-    const dataURL = maskToDataURL(composited)
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+    try {
+      const composited = compositeMask(samMask)
+      const dataURL = await maskToDataURL(composited)
 
-    const src = map.getSource(PAINT_SOURCE)
-    if (src) {
-      src.updateImage({ url: dataURL, coordinates: chipCorners })
-    } else {
-      map.addSource(PAINT_SOURCE, {
-        type: 'image',
-        url: dataURL,
-        coordinates: chipCorners,
-      })
-      map.addLayer({
-        id: PAINT_LAYER,
-        type: 'raster',
-        source: PAINT_SOURCE,
-      })
+      const src = map.getSource(PAINT_SOURCE)
+      if (src) {
+        src.updateImage({ url: dataURL, coordinates: chipCorners })
+      } else {
+        map.addSource(PAINT_SOURCE, {
+          type: 'image',
+          url: dataURL,
+          coordinates: chipCorners,
+        })
+        map.addLayer({
+          id: PAINT_LAYER,
+          type: 'raster',
+          source: PAINT_SOURCE,
+        })
+      }
+    } finally {
+      inFlightRef.current = false
     }
   }, [map, chipCorners, compositeMask, samMask])
 

--- a/src/PaintbrushOverlay.jsx
+++ b/src/PaintbrushOverlay.jsx
@@ -11,7 +11,7 @@ export default function PaintbrushOverlay({
   brushSize,
   paintAt,
   compositeMask,
-  samMask,
+  samMaskRef,
   onMaskUpdate,
 }) {
   const paintingRef = useRef(false)
@@ -90,7 +90,7 @@ export default function PaintbrushOverlay({
     if (inFlightRef.current) return
     inFlightRef.current = true
     try {
-      const composited = compositeMask(samMask)
+      const composited = compositeMask(samMaskRef.current)
       const dataURL = await maskToDataURL(composited)
 
       const src = map.getSource(PAINT_SOURCE)
@@ -111,7 +111,7 @@ export default function PaintbrushOverlay({
     } finally {
       inFlightRef.current = false
     }
-  }, [map, chipCorners, compositeMask, samMask])
+  }, [map, chipCorners, compositeMask, samMaskRef])
 
   // Clean up the MapLibre source/layer when paint mode deactivates or chip changes
   useEffect(() => {
@@ -190,7 +190,7 @@ export default function PaintbrushOverlay({
       // Flush final render and notify parent
       updateOverlay()
       if (onMaskUpdate) {
-        onMaskUpdate(compositeMask(samMask))
+        onMaskUpdate(compositeMask(samMaskRef.current))
       }
     }
 
@@ -208,7 +208,7 @@ export default function PaintbrushOverlay({
         map.dragPan.enable()
       }
     }
-  }, [map, paintMode, chipCorners, brushSize, screenToCanvas, paintAt, updateOverlay, onMaskUpdate, compositeMask, samMask])
+  }, [map, paintMode, chipCorners, brushSize, screenToCanvas, paintAt, updateOverlay, onMaskUpdate, compositeMask, samMaskRef])
 
   // No DOM element needed — everything renders through MapLibre
   return null

--- a/src/StatusBar.jsx
+++ b/src/StatusBar.jsx
@@ -1,4 +1,4 @@
-function StatusBar({ selectedChipId, clickPoints, maskIndex, maskResults, paintMode, brushSize, deleteMode }) {
+function StatusBar({ selectedChipId, clickPoints, maskIndex, maskInfo, paintMode, brushSize, deleteMode }) {
   if (deleteMode) {
     return (
       <div className="status-bar status-bar-active" style={{ borderColor: '#ef4444' }}>
@@ -31,12 +31,12 @@ function StatusBar({ selectedChipId, clickPoints, maskIndex, maskResults, paintM
     )
   }
 
-  if (maskIndex >= 0 && maskResults) {
+  if (maskIndex >= 0 && maskInfo) {
     return (
       <div className="status-bar status-bar-active">
         <span className="status-bar-mask">
-          Mask {maskIndex + 1}/{maskResults.masks.length}
-          {' '}&middot; IoU {maskResults.scores[maskIndex].toFixed(2)}
+          Mask {maskIndex + 1}/{maskInfo.count}
+          {' '}&middot; IoU {maskInfo.scores[maskIndex].toFixed(2)}
           {' '}&middot; {clickPoints.length} point{clickPoints.length !== 1 ? 's' : ''}
         </span>
         <span className="status-bar-hints">

--- a/src/hooks/usePaintbrush.js
+++ b/src/hooks/usePaintbrush.js
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState, useCallback, useMemo } from 'react'
 import { SAM_MASK_SIZE } from '../sam'
 
 const PIXELS = SAM_MASK_SIZE * SAM_MASK_SIZE
@@ -12,6 +12,8 @@ export function usePaintbrush() {
   const [paintMode, setPaintMode] = useState(null) // null | 'add' | 'erase'
   const [brushSize, setBrushSize] = useState(DEFAULT_BRUSH_SIZE)
   const correctionsRef = useRef(new Uint8Array(PIXELS))
+  // Pre-allocated buffer for compositeMask — callers must read immediately, not cache across frames
+  const compositeRef = useRef(new Float32Array(PIXELS))
 
   const paintAt = useCallback((x, y) => {
     const buf = correctionsRef.current
@@ -35,7 +37,7 @@ export function usePaintbrush() {
 
   const compositeMask = useCallback((samMask) => {
     const buf = correctionsRef.current
-    const out = new Float32Array(PIXELS)
+    const out = compositeRef.current
     for (let i = 0; i < PIXELS; i++) {
       const sam = samMask ? samMask[i] : 0
       const corr = buf[i]
@@ -58,7 +60,7 @@ export function usePaintbrush() {
     setBrushSize((prev) => Math.max(MIN_BRUSH, Math.min(MAX_BRUSH, prev + delta)))
   }, [])
 
-  return {
+  return useMemo(() => ({
     paintMode,
     setPaintMode,
     brushSize,
@@ -68,5 +70,5 @@ export function usePaintbrush() {
     paintAt,
     compositeMask,
     clearCorrections,
-  }
+  }), [paintMode, brushSize, paintAt, compositeMask, clearCorrections, adjustBrushSize])
 }

--- a/src/sam.js
+++ b/src/sam.js
@@ -152,14 +152,20 @@ export function maskToPngBase64(mask, width = SAM_MASK_SIZE, height = SAM_MASK_S
 }
 
 /**
- * Convert a binary mask (512x512) to a data URL for use as a map image overlay.
+ * Convert a binary mask (512x512) to an object URL for use as a map image overlay.
  * Mask pixels are rendered as semi-transparent blue.
+ * Uses toBlob() (async) to avoid synchronous PNG encoding on the main thread.
  */
-export function maskToDataURL(mask, width = 512, height = 512) {
-  const canvas = document.createElement('canvas')
-  canvas.width = width
-  canvas.height = height
-  const ctx = canvas.getContext('2d')
+let _overlayCanvas = null
+let _prevObjectURL = null
+
+export async function maskToDataURL(mask, width = 512, height = 512) {
+  if (!_overlayCanvas) {
+    _overlayCanvas = document.createElement('canvas')
+  }
+  _overlayCanvas.width = width
+  _overlayCanvas.height = height
+  const ctx = _overlayCanvas.getContext('2d')
   const imageData = ctx.createImageData(width, height)
 
   for (let i = 0; i < mask.length; i++) {
@@ -174,5 +180,9 @@ export function maskToDataURL(mask, width = 512, height = 512) {
   }
 
   ctx.putImageData(imageData, 0, 0)
-  return canvas.toDataURL()
+
+  const blob = await new Promise(resolve => _overlayCanvas.toBlob(resolve))
+  if (_prevObjectURL) URL.revokeObjectURL(_prevObjectURL)
+  _prevObjectURL = URL.createObjectURL(blob)
+  return _prevObjectURL
 }

--- a/src/views/useLabelingView.js
+++ b/src/views/useLabelingView.js
@@ -63,7 +63,7 @@ function getMapBbox(map) {
 export function useLabelingView({ active, map, featureById, layerProviders = [] }) {
   const [selectedChipId, setSelectedChipId] = useState(null)
   const [clickPoints, setClickPoints] = useState([])
-  const [maskResults, setMaskResults] = useState(null)
+  const [maskInfo, setMaskInfo] = useState(null) // { count, scores } — lightweight summary for UI
   const [maskIndex, setMaskIndex] = useState(-1)
   const [showLabels, setShowLabels] = useState(false)
   const [previewGeojson, setPreviewGeojson] = useState(null)
@@ -97,7 +97,6 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
   useEffect(() => { showLabelsRef.current = showLabels }, [showLabels])
   useEffect(() => { previewGeojsonRef.current = previewGeojson }, [previewGeojson])
   useEffect(() => { deleteModeRef.current = deleteMode }, [deleteMode])
-  useEffect(() => { maskResultsRef.current = maskResults }, [maskResults])
   useEffect(() => { maskIndexRef.current = maskIndex }, [maskIndex])
   useEffect(() => { paintModeRef.current = paintbrush.paintMode }, [paintbrush.paintMode])
 
@@ -270,7 +269,9 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       clearPointMarkers()
       points.length = 0
       lastLowResMaskRef.current = null
-      setMaskResults(null)
+      maskResultsRef.current = null
+      currentSamMaskRef.current = null
+      setMaskInfo(null)
       setMaskIndex(-1)
       setClickPoints([])
       removePreviewLayer()
@@ -354,7 +355,9 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
 
       const maskPrior = getMaskPrior()
       const { masks, scores, lowResMasks } = await runSamDecoder(chip.embedding, points, maskPrior)
-      setMaskResults({ masks, scores, lowResMasks, imageCoords: chip.corners })
+      maskResultsRef.current = { masks, scores, lowResMasks, imageCoords: chip.corners }
+      currentSamMaskRef.current = masks[0]
+      setMaskInfo({ count: masks.length, scores })
       setMaskIndex(0)
       showMask(masks[0], chip.corners)
 
@@ -444,7 +447,9 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
         if (map.getLayer('mask-overlay')) map.removeLayer('mask-overlay')
         if (map.getSource('mask-overlay')) map.removeSource('mask-overlay')
         lastLowResMaskRef.current = null
-        setMaskResults(null)
+        maskResultsRef.current = null
+        currentSamMaskRef.current = null
+        setMaskInfo(null)
         setMaskIndex(-1)
         return
       }
@@ -452,7 +457,9 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
 
       const maskPrior = getMaskPrior()
       const { masks, scores, lowResMasks } = await runSamDecoder(chip.embedding, points, maskPrior)
-      setMaskResults({ masks, scores, lowResMasks, imageCoords: chip.corners })
+      maskResultsRef.current = { masks, scores, lowResMasks, imageCoords: chip.corners }
+      currentSamMaskRef.current = masks[0]
+      setMaskInfo({ count: masks.length, scores })
       setMaskIndex(0)
       showMask(masks[0], chip.corners)
       if (lowResMasks && lowResMasks.length > 0) {
@@ -697,6 +704,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
         const idx = e.key === ']'
           ? (prev + 1) % r.masks.length
           : (prev - 1 + r.masks.length) % r.masks.length
+        currentSamMaskRef.current = r.masks[idx]
         showMask(r.masks[idx], r.imageCoords)
         if (r.lowResMasks && r.lowResMasks[idx]) {
           lastLowResMaskRef.current = new Float32Array(r.lowResMasks[idx])
@@ -769,20 +777,19 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
     ...layerProviders.flatMap(lp => lp.controls || []),
   ], [showLabels, toggleLabels, layerProviders])
 
-  // Get the current SAM mask for compositing
-  const currentSamMask = useMemo(
-    () => maskResults && maskIndex >= 0 ? maskResults.masks[maskIndex] : null,
-    [maskResults, maskIndex],
-  )
+  // Current SAM mask for compositing — kept in a ref so large binary data
+  // never enters React state. Updated by effects/handlers that change masks.
+  const currentSamMaskRef = useRef(null)
+
   return {
     selectedChipId,
     clickPoints,
-    maskResults,
+    maskInfo,
     maskIndex,
     pluginControls,
     paintbrush,
     chipCorners,
-    currentSamMask,
+    currentSamMaskRef,
     handleMaskUpdate,
     previewGeojson,
     deleteMode,

--- a/src/views/useLabelingView.js
+++ b/src/views/useLabelingView.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import maplibregl from 'maplibre-gl'
 import { initSamDecoder, isDecoderReady, runSamDecoder, maskToDataURL, maskToPngBase64 } from '../sam'
 import { loadNpy } from '../npy'
@@ -68,7 +68,10 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
   const [showLabels, setShowLabels] = useState(false)
   const [previewGeojson, setPreviewGeojson] = useState(null)
   const [deleteMode, setDeleteMode] = useState(false)
+  const [chipCorners, setChipCorners] = useState(null)
   const paintbrush = usePaintbrush()
+  const paintbrushRef = useRef(paintbrush)
+  useEffect(() => { paintbrushRef.current = paintbrush }, [paintbrush])
 
   // Mutable handler state (refs)
   const chipRef = useRef({ id: null, corners: null, embedding: null })
@@ -197,12 +200,10 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
     }
 
     fetchLabels()
-    const pollInterval = setInterval(fetchLabels, 5000)
     map.on('moveend', onMoveEnd)
 
     return () => {
       cancelled = true
-      clearInterval(pollInterval)
       clearTimeout(debounceTimer)
       map.off('moveend', onMoveEnd)
       if (map.getLayer('labels-fill')) map.removeLayer('labels-fill')
@@ -282,6 +283,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       chip.corners = null
       chip.embedding = null
       setSelectedChipId(null)
+      setChipCorners(null)
       if (map.getLayer('chips-outline')) {
         map.setPaintProperty('chips-outline', 'line-color', [
           'match', ['get', 'split'],
@@ -309,20 +311,23 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       markers.push(marker)
     }
 
-    function showMask(mask, imageCoords) {
-      const dataURL = maskToDataURL(mask)
-      if (map.getLayer('mask-overlay')) map.removeLayer('mask-overlay')
-      if (map.getSource('mask-overlay')) map.removeSource('mask-overlay')
-      map.addSource('mask-overlay', {
-        type: 'image',
-        url: dataURL,
-        coordinates: imageCoords,
-      })
-      map.addLayer({
-        id: 'mask-overlay',
-        type: 'raster',
-        source: 'mask-overlay',
-      })
+    async function showMask(mask, imageCoords) {
+      const dataURL = await maskToDataURL(mask)
+      const src = map.getSource('mask-overlay')
+      if (src) {
+        src.updateImage({ url: dataURL, coordinates: imageCoords })
+      } else {
+        map.addSource('mask-overlay', {
+          type: 'image',
+          url: dataURL,
+          coordinates: imageCoords,
+        })
+        map.addLayer({
+          id: 'mask-overlay',
+          type: 'raster',
+          source: 'mask-overlay',
+        })
+      }
       raiseLabels(map)
     }
 
@@ -395,6 +400,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       chip.id = chipId
       chip.corners = imageCoords
       setSelectedChipId(chipId)
+      setChipCorners(imageCoords)
 
       const lngs = imageCoords.map(c => c[0])
       const lats = imageCoords.map(c => c[1])
@@ -592,7 +598,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
             if (res.ok) {
               console.log('Label saved:', res.label_id)
               clearSegmentation()
-              paintbrush.clearCorrections()
+              paintbrushRef.current.clearCorrections()
               if (showLabelsRef.current && map.getSource('labels')) {
                 fetch(data.labelsUrl(getMapBbox(map))).then(r => r.json()).then(geojson => {
                   if (map.getSource('labels')) map.getSource('labels').setData(geojson)
@@ -610,7 +616,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
         if (!r || r.masks.length === 0) return
         const idx = maskIndexRef.current >= 0 ? maskIndexRef.current : 0
         const samMask = r.masks[idx]
-        const finalMask = paintbrush.compositeMask(samMask)
+        const finalMask = paintbrushRef.current.compositeMask(samMask)
         const base64 = maskToPngBase64(finalMask)
         pendingMaskRef.current = base64
         data.vectorizePreview(chip.id, base64, 'positive').then((feature) => {
@@ -630,7 +636,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       if (e.key === 'Escape') {
         e.preventDefault()
         if (paintModeRef.current) {
-          paintbrush.setPaintMode(null)
+          paintbrushRef.current.setPaintMode(null)
           return
         }
         deselectChip()
@@ -644,7 +650,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
           map.dragPan.enable()
         } else {
           setDeleteMode(true)
-          paintbrush.setPaintMode(null)
+          paintbrushRef.current.setPaintMode(null)
           setShowLabels(true)
         }
         return
@@ -655,25 +661,25 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       // Paintbrush shortcuts
       if (e.key === 'b' || e.key === 'B') {
         if (!chip.id) return
-        paintbrush.setPaintMode((prev) => prev ? null : 'add')
+        paintbrushRef.current.setPaintMode((prev) => prev ? null : 'add')
         return
       }
       if (e.key === 'a' || e.key === 'A') {
         if (!chip.id) return
-        paintbrush.setPaintMode('add')
+        paintbrushRef.current.setPaintMode('add')
         return
       }
       if (e.key === 'e' || e.key === 'E') {
         if (!chip.id) return
-        paintbrush.setPaintMode('erase')
+        paintbrushRef.current.setPaintMode('erase')
         return
       }
       if (e.key === '=' || e.key === '+') {
-        paintbrush.adjustBrushSize(2)
+        paintbrushRef.current.adjustBrushSize(2)
         return
       }
       if (e.key === '-' || e.key === '_') {
-        paintbrush.adjustBrushSize(-2)
+        paintbrushRef.current.adjustBrushSize(-2)
         return
       }
 
@@ -695,7 +701,7 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
         if (r.lowResMasks && r.lowResMasks[idx]) {
           lastLowResMaskRef.current = new Float32Array(r.lowResMasks[idx])
         }
-        paintbrush.clearCorrections()
+        paintbrushRef.current.clearCorrections()
         return idx
       })
     }
@@ -730,39 +736,44 @@ export function useLabelingView({ active, map, featureById, layerProviders = [] 
       map.off('mousemove', onDeleteMouseMove)
       map.off('mouseup', onDeleteMouseUp)
     }
-  }, [map, active, featureById, paintbrush])
+  // paintbrush methods are accessed via paintbrushRef to avoid tearing down
+  // all map handlers on every paintbrush state change.
+  }, [map, active, featureById])
 
   // Update the map mask overlay when paintbrush modifies the composited mask
-  const handleMaskUpdate = useCallback((composited) => {
+  const handleMaskUpdate = useCallback(async (composited) => {
     if (!map || !chipRef.current.corners) return
-    const dataURL = maskToDataURL(composited)
-    if (map.getLayer('mask-overlay')) map.removeLayer('mask-overlay')
-    if (map.getSource('mask-overlay')) map.removeSource('mask-overlay')
-    map.addSource('mask-overlay', {
-      type: 'image',
-      url: dataURL,
-      coordinates: chipRef.current.corners,
-    })
-    map.addLayer({
-      id: 'mask-overlay',
-      type: 'raster',
-      source: 'mask-overlay',
-    })
+    const dataURL = await maskToDataURL(composited)
+    const src = map.getSource('mask-overlay')
+    if (src) {
+      src.updateImage({ url: dataURL, coordinates: chipRef.current.corners })
+    } else {
+      map.addSource('mask-overlay', {
+        type: 'image',
+        url: dataURL,
+        coordinates: chipRef.current.corners,
+      })
+      map.addLayer({
+        id: 'mask-overlay',
+        type: 'raster',
+        source: 'mask-overlay',
+      })
+    }
     raiseLabels(map)
   }, [map])
 
   // Collect controls from all layer providers
-  const labelsControl = {
-    label: 'Labels',
-    active: showLabels,
-    onToggle: () => setShowLabels(prev => !prev),
-  }
-  const pluginControls = [labelsControl, ...layerProviders.flatMap(lp => lp.controls || [])]
+  const toggleLabels = useCallback(() => setShowLabels(prev => !prev), [])
+  const pluginControls = useMemo(() => [
+    { label: 'Labels', active: showLabels, onToggle: toggleLabels },
+    ...layerProviders.flatMap(lp => lp.controls || []),
+  ], [showLabels, toggleLabels, layerProviders])
 
   // Get the current SAM mask for compositing
-  const currentSamMask = maskResults && maskIndex >= 0 ? maskResults.masks[maskIndex] : null
-  const chipCorners = chipRef.current.corners
-
+  const currentSamMask = useMemo(
+    () => maskResults && maskIndex >= 0 ? maskResults.masks[maskIndex] : null,
+    [maskResults, maskIndex],
+  )
   return {
     selectedChipId,
     clickPoints,


### PR DESCRIPTION
The PR optimizes the frontend. The main changes are the application of memoization to objects that shoudn't trigger UI rerenders and the removal of all image data from React state - the root cause of most of the slowdown was SAM masks being passed through state. Now that writes to the mask are imperative and do not trigger re-renders, UI has been sped up by an order of magnitude